### PR TITLE
Bugfix that allow the engine to call multiple times the process method

### DIFF
--- a/dg-core/src/main/java/org/finra/datagenerator/distributor/multithreaded/DefaultDistributor.java
+++ b/dg-core/src/main/java/org/finra/datagenerator/distributor/multithreaded/DefaultDistributor.java
@@ -115,6 +115,10 @@ public class DefaultDistributor implements SearchDistributor {
 
             // Now, wait for the output thread to get done
             outputThread.join();
+
+            // Now that it is finished, reset flags.
+            searchExitFlag.set(false);   
+            hardExitFlag.set(false);
             log.info("DONE");
         } catch (InterruptedException ex) {
             log.info("Interrupted !!... exiting", ex);


### PR DESCRIPTION
For some projects it might be necessary to generate data some times in a row. This is not easily possible now because the thread flags (hardExitFlag and searchExitFlag) on DefaultDistributor are never reset and the produceOutput will never produce the output again, but with this simple change it makes possible to recall the engine.process method and re-generate data.
