### PR TITLE
Modified LowerBoundTest2 in NegativeBoundHiveDateTest

### DIFF
--- a/dg-core/src/main/java/org/finra/datagenerator/engine/scxml/tags/boundary/BoundaryDate.java
+++ b/dg-core/src/main/java/org/finra/datagenerator/engine/scxml/tags/boundary/BoundaryDate.java
@@ -57,6 +57,11 @@ public abstract class BoundaryDate<T extends BoundaryActionDate> implements Cust
         }
     }
 
+    /**
+     *
+     * @param year to check if it is a leap year
+     * @return true if the year is a leap year
+     */
     public boolean isLeapYear(int year) {
         if (year % 4 == 0) {
             if (year % 100 == 0) {

--- a/dg-core/src/main/java/org/finra/datagenerator/engine/scxml/tags/boundary/BoundaryDate.java
+++ b/dg-core/src/main/java/org/finra/datagenerator/engine/scxml/tags/boundary/BoundaryDate.java
@@ -57,6 +57,19 @@ public abstract class BoundaryDate<T extends BoundaryActionDate> implements Cust
         }
     }
 
+    public boolean isLeapYear(int year) {
+        if (year % 4 == 0) {
+            if (year % 100 == 0) {
+                if (year % 400 == 0) {
+                    return true;
+                }
+            } else {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /**
      * @param isNullable isNullable
      * @param earliest   lower boundary date
@@ -65,20 +78,11 @@ public abstract class BoundaryDate<T extends BoundaryActionDate> implements Cust
      */
     public List<String> positiveCase(boolean isNullable, String earliest, String latest) {
         List<String> values = new LinkedList<>();
-        boolean isLeapYear = false;
+
         int earlyDay = Integer.parseInt(earliest.substring(8, 10));
         int earlyMonth = Integer.parseInt(earliest.substring(5, 7));
         int earlyYear = Integer.parseInt(earliest.substring(0, 4));
-
-        if (earlyYear % 4 == 0) {
-            if (earlyYear % 100 == 0) {
-                if (earlyYear % 400 == 0) {
-                    isLeapYear = true;
-                }
-            } else {
-                isLeapYear = true;
-            }
-        }
+        boolean isLeapYear = isLeapYear(earlyYear);
 
         // prepend 0 for months 1 - 9
         String earlyMo = (Integer.toString(earlyMonth).length() < 2 ? "0" + earlyMonth : "" + earlyMonth);
@@ -96,7 +100,15 @@ public abstract class BoundaryDate<T extends BoundaryActionDate> implements Cust
             if (isLeapYear && earlyDay < 29) {
                 earlyDay++;
             } else if (!isLeapYear && earlyDay < 28) {
-                earlyDay++;
+                if (earlyDay < 28) {
+                    earlyDay++;
+                } else {
+                    earlyDay = 1;
+                    earlyMonth = 3;
+                }
+            } else {
+                earlyDay = 1;
+                earlyMonth = 3;
             }
         } else {
             if (earlyMonth < 12) {
@@ -129,10 +141,10 @@ public abstract class BoundaryDate<T extends BoundaryActionDate> implements Cust
             } else if (lateMonth == 3) {
                 if (isLeapYear) {
                     lateDay = 29;
-                    lateMonth--;
+                    lateMonth = 2;
                 } else {
                     lateDay = 28;
-                    lateMonth--;
+                    lateMonth = 2;
                 }
             } else {
                 if (lateYear > 1970) {
@@ -172,20 +184,10 @@ public abstract class BoundaryDate<T extends BoundaryActionDate> implements Cust
      */
     public List<String> negativeCase(boolean isNullable, String earliest, String latest) {
         List<String> values = new LinkedList<>();
-        boolean isLeapYear = false;
         int earlyDay = Integer.parseInt(earliest.substring(8, 10));
         int earlyMonth = Integer.parseInt(earliest.substring(5, 7));
         int earlyYear = Integer.parseInt(earliest.substring(0, 4));
-
-        if (earlyYear % 4 == 0) {
-            if (earlyYear % 100 == 0) {
-                if (earlyYear % 400 == 0) {
-                    isLeapYear = true;
-                }
-            } else {
-                isLeapYear = true;
-            }
-        }
+        boolean isLeapYear = isLeapYear(earlyYear);
 
         if (earlyDay > 1) {
             earlyDay--;
@@ -225,10 +227,20 @@ public abstract class BoundaryDate<T extends BoundaryActionDate> implements Cust
             && lateDay < 30) {
             lateDay++;
         } else if (lateMonth == 2) {
-            if (isLeapYear && lateDay < 29) {
-                lateDay++;
-            } else if (!isLeapYear && lateDay < 28) {
-                lateDay++;
+            if (isLeapYear) {
+                if (lateDay < 29) {
+                    lateDay++;
+                } else {
+                    lateDay = 1;
+                    lateMonth = 3;
+                }
+            } else {
+                if (lateDay < 28) {
+                    lateDay++;
+                } else {
+                    lateDay = 1;
+                    lateMonth = 3;
+                }
             }
         } else {
             if (lateMonth < 12) {

--- a/dg-core/src/main/java/org/finra/datagenerator/engine/scxml/tags/boundary/BoundaryDate.java
+++ b/dg-core/src/main/java/org/finra/datagenerator/engine/scxml/tags/boundary/BoundaryDate.java
@@ -134,6 +134,7 @@ public abstract class BoundaryDate<T extends BoundaryActionDate> implements Cust
         int lateDay = Integer.parseInt(latest.substring(8, 10));
         int lateMonth = Integer.parseInt(latest.substring(5, 7));
         int lateYear = Integer.parseInt(latest.substring(0, 4));
+        isLeapYear = isLeapYear(lateYear);
 
         if (lateDay > 1) {
             lateDay--;

--- a/dg-core/src/test/java/org/finra/datagenerator/engine/scxml/tags/boundary/NegativeBoundHiveDateTest.java
+++ b/dg-core/src/test/java/org/finra/datagenerator/engine/scxml/tags/boundary/NegativeBoundHiveDateTest.java
@@ -91,19 +91,18 @@ public class NegativeBoundHiveDateTest {
         NegativeBoundHiveDate.NegativeBoundHiveDateTag tag = new NegativeBoundHiveDate.NegativeBoundHiveDateTag();
         tag.setName("name");
 
-        Calendar currDate = Calendar.getInstance();
-        String current = new SimpleDateFormat("yyyy-MM-dd").format(currDate.getTime());
-        int day = Integer.parseInt(current.substring(8, 10));
-        int month = Integer.parseInt(current.substring(5, 7));
-        int year = Integer.parseInt(current.substring(0, 4));
+        Calendar nextDate = Calendar.getInstance();
+        nextDate.add(Calendar.DATE, +1);
+        String next = new SimpleDateFormat("yyyy-MM-dd").format(nextDate.getTime());
 
-        String earlyMo = (Integer.toString(month).length() < 2 ? "0" + month : "" + month);
-        String earlyDy = (Integer.toString(day).length() < 2 ? "0" + ++day : "" + ++day);
+        String day = next.substring(8, 10);
+        String month = next.substring(5, 7);
+        String year = next.substring(0, 4);
 
         List<Map<String, String>> newList = dateTest.pipelinePossibleStates(tag, listOfMaps);
         Assert.assertEquals(newList.get(0).get("name"), "1969-12-31");
-        Assert.assertEquals(newList.get(1).get("name"), year + "-" + earlyMo + "-" + earlyDy);
-        Assert.assertEquals(newList.get(2).get("name"), earlyMo + "-" + earlyDy + "-" + year);
+        Assert.assertEquals(newList.get(1).get("name"), next);
+        Assert.assertEquals(newList.get(2).get("name"), month + "-" + day + "-" + year);
     }
 
     /**

--- a/dg-core/src/test/java/org/finra/datagenerator/engine/scxml/tags/boundary/PositiveBoundHiveDateTest.java
+++ b/dg-core/src/test/java/org/finra/datagenerator/engine/scxml/tags/boundary/PositiveBoundHiveDateTest.java
@@ -94,20 +94,26 @@ public class PositiveBoundHiveDateTest {
         tag.setName("name");
 
         Calendar currDate = Calendar.getInstance();
-        String current = new SimpleDateFormat("yyyy-MM-dd").format(currDate.getTime());
-        int day = Integer.parseInt(current.substring(8, 10));
-        int month = Integer.parseInt(current.substring(5, 7));
-        int year = Integer.parseInt(current.substring(0, 4));
+        Calendar prevDate = Calendar.getInstance();
+        prevDate.add(Calendar.DATE, -1);
 
-        String earlyMo = (Integer.toString(month).length() < 2 ? "0" + month : "" + month);
-        String earlyDy = (Integer.toString(day).length() < 2 ? "0" + --day : "" + --day);
+        String current = new SimpleDateFormat("yyyy-MM-dd").format(currDate.getTime());
+        String prev = new SimpleDateFormat("yyyy-MM-dd").format(prevDate.getTime());
+
+        String day = current.substring(8, 10);
+        String month = current.substring(5, 7);
+        String year = current.substring(0, 4);
+
+        String prevDay = prev.substring(8, 10);
+        String prevMonth = prev.substring(5, 7);
+        String preYear = prev.substring(0, 4);
 
         List<Map<String, String>> newList = dateTest.pipelinePossibleStates(tag, listOfMaps);
+
         Assert.assertEquals(newList.get(0).get("name"), "1970-01-01");
         Assert.assertEquals(newList.get(1).get("name"), "1970-01-02");
-        Assert.assertEquals(newList.get(2).get("name"), year + "-" + earlyMo + "-" + earlyDy);
-        earlyDy = Integer.toString(day).length() < 2 ? "0" + ++day : "" + ++day;
-        Assert.assertEquals(newList.get(3).get("name"), year + "-" + earlyMo + "-" + earlyDy);
+        Assert.assertEquals(newList.get(2).get("name"), preYear + "-" + prevMonth + "-" + prevDay);
+        Assert.assertEquals(newList.get(3).get("name"), year + "-" + month + "-" + day);
     }
 
     /**


### PR DESCRIPTION
I made the changes and checked them in, but am getting the following exception during the execution of org.finra.datagenerator.consumer.EquivalenceClassTransformerTest:

Exception in thread "dag-scheduler-event-loop" java.lang.UnsatisfiedLinkError: org.xerial.snappy.SnappyNative.maxCompressedLength(I)I
        at org.xerial.snappy.SnappyNative.maxCompressedLength(Native Method)
        at org.xerial.snappy.Snappy.maxCompressedLength(Snappy.java:344)
        at org.xerial.snappy.SnappyOutputStream.<init>(SnappyOutputStream.java:90)
        at org.xerial.snappy.SnappyOutputStream.<init>(SnappyOutputStream.java:83)
        at org.apache.spark.io.SnappyCompressionCodec.compressedOutputStream(CompressionCodec.scala:156)
        at org.apache.spark.broadcast.TorrentBroadcast$$anonfun$4.apply(TorrentBroadcast.scala:200)
        at org.apache.spark.broadcast.TorrentBroadcast$$anonfun$4.apply(TorrentBroadcast.scala:200)
        at scala.Option.map(Option.scala:145)
        at org.apache.spark.broadcast.TorrentBroadcast$.blockifyObject(TorrentBroadcast. scala:200)
        at org.apache.spark.broadcast.TorrentBroadcast.writeBlocks(TorrentBroadcast.scala:102)
        at org.apache.spark.broadcast.TorrentBroadcast.<init>(TorrentBroadcast.scala:85)
        at org.apache.spark.broadcast.TorrentBroadcastFactory.newBroadcast(TorrentBroadcastFactory.scala:34)
        at org.apache.spark.broadcast.BroadcastManager.newBroadcast(BroadcastManager.scala:63)
        at org.apache.spark.SparkContext.broadcast(SparkContext.scala:1327)
        at org.apache.spark.scheduler.DAGScheduler.org$apache$spark$scheduler$DAGScheduler$$submitMissingTasks(DAGScheduler.scala:861)
        at org.apache.spark.scheduler.DAGScheduler.org$apache$spark$scheduler$DAGScheduler$$submitStage(DAGScheduler.scala:772)
        at org.apache.spark.scheduler.DAGScheduler.handleJobSubmitted(DAGScheduler.scala:757)
        at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.doOnReceive(DAGScheduler.scala:1466)
        at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:1458)
        at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:1447)
        at org.apache.spark.util.EventLoop$$anon$1.run(EventLoop.scala:48)

The test never completes and hangs indefinitely. Even after killing the terminal, mvn clean fails because it cannot delete the surefire.jar since it is still running in the JVM.

I ran all my tests locally, and was able to build core with the –DskipTests flag, so will go ahead with the pull request.