### PR TITLE
Added Regex module to forcefully prohibit clrf line endings

### DIFF
--- a/config/sun_checkstyle.xml
+++ b/config/sun_checkstyle.xml
@@ -48,6 +48,10 @@
 
     <!-- Checks whether files end with a new line.                        -->
     <!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
+    <module name="RegexpMultiline">
+        <property name="format" value="\r\n"/>
+        <property name="message" value="CRLF line endings are prohibited"/>
+    </module>
     <!--module name="NewlineAtEndOfFile"/-->
     <!-- Checks that property files contain the same keys.         -->
     <!-- See http://checkstyle.sf.net/config_misc.html#Translation -->


### PR DESCRIPTION
Should fix issue #268 by refusing to build on windows style line endings